### PR TITLE
Add stylelint-prettier as a stylelint plugin.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,4 +20,5 @@ npm install -g stylelint-rscss@0.4.0
 npm install -g stylelint-selector-bem-pattern@2.0.0
 npm install -g stylelint-config-slds@1.0.7
 npm install -g stylelint-config-prettier@4.0.0
+npm install -g prettier@1.16.4
 npm install -g stylelint-prettier@1.0.6

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,3 +20,4 @@ npm install -g stylelint-rscss@0.4.0
 npm install -g stylelint-selector-bem-pattern@2.0.0
 npm install -g stylelint-config-slds@1.0.7
 npm install -g stylelint-config-prettier@4.0.0
+npm install -g stylelint-prettier@1.0.6


### PR DESCRIPTION
It would be really :heart: if codacy supported prettier as a plugin of stylelint. This PR is doing this, by installing `prettier` and then `stylelint-prettier`.

This would allow codacy to support the below configuration without throwing a warning:

```JSON
{
  "plugins": ["stylelint-prettier"],
  "rules": {
    "prettier/prettier": true
  }
}
```
