### PR TITLE
Add styled-components dependencies

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,3 +24,5 @@ npm install -g stylelint-config-prettier@5.2.0
 npm install -g stylelint-config-css-modules@1.4.0
 npm install -g prettier@1.18.2
 npm install -g stylelint-prettier@1.1.1
+npm install -g stylelint-config-styled-components@0.1.1
+npm install -g stylelint-processor-styled-components@1.5.2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,4 +25,4 @@ npm install -g stylelint-config-css-modules@1.4.0
 npm install -g prettier@1.18.2
 npm install -g stylelint-prettier@1.1.1
 npm install -g stylelint-config-styled-components@0.1.1
-npm install -g stylelint-processor-styled-components@1.5.2
+npm install -g stylelint-processor-styled-components@1.8.0


### PR DESCRIPTION
Allows to process styled-components with stylelint.


Basicly styled-components is a way to allow for styling react classes in react. For example:

```
  const RedHeadline = styled.h1`
    color: red
  `,
```



And stylelint can lint them via these 2 dependencies.

Example .stylelintrc:

```
{
  "processors": ["stylelint-processor-styled-components"],
  "extends": [
    "stylelint-config-recommended",
    "stylelint-config-styled-components"
  ]
}
```

