### PR TITLE
fix: Return empty results if no file is analysed CY-2518

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   codacy: codacy/base@2.9.3
-  codacy_plugins_test: codacy/plugins-test@0.10.6
+  codacy_plugins_test: codacy/plugins-test@0.14.2
 
 workflows:
   version: 2

--- a/src/main/resources/docs/multiple-tests/with-config-file/results.xml
+++ b/src/main/resources/docs/multiple-tests/with-config-file/results.xml
@@ -18,6 +18,7 @@
         <error source="indentation" line="20" message="Expected indentation of 2 spaces (indentation)" severity="error" />
 
         <error source="length-zero-no-unit" line="15" message="Unexpected unit (length-zero-no-unit)" severity="error" />
+        <error source="length-zero-no-unit" line="15" message="Unexpected unit (length-zero-no-unit)" severity="error" />
     </file>
     <file name="test2.less">
         <error source="color-hex-case" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaaaaa&quot; (color-hex-case)" severity="error" />
@@ -25,6 +26,7 @@
 
         <error source="number-leading-zero" line="14" message="Unexpected leading zero (number-leading-zero)" severity="error" />
 
+        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="error" />
         <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="error" />
 
         <error source="no-eol-whitespace" line="4" message="Unexpected whitespace at end of line (no-eol-whitespace)" severity="error" />
@@ -55,6 +57,7 @@
 
         <error source="number-leading-zero" line="14" message="Unexpected leading zero (number-leading-zero)" severity="error" />
 
+        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="error" />
         <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="error" />
 
         <error source="indentation" line="2" message="Expected indentation of 2 spaces (indentation)" severity="error" />


### PR DESCRIPTION
This should avoid errors when running this locally without a codacyrc