### PR TITLE
Improve patterns levels CY-4851

### DIFF
--- a/src/main/resources/docs/description/alpha-value-notation.md
+++ b/src/main/resources/docs/description/alpha-value-notation.md
@@ -9,7 +9,7 @@ Specify percentage or number notation for alpha-values.
  *                         This notation */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/at-rule-blacklist.md
+++ b/src/main/resources/docs/description/at-rule-blacklist.md
@@ -1,6 +1,6 @@
 # at-rule-blacklist
 
-**_Deprecated: Instead use the [`at-rule-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/at-rule-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`at-rule-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/at-rule-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed at-rules.
 

--- a/src/main/resources/docs/description/at-rule-empty-line-before.md
+++ b/src/main/resources/docs/description/at-rule-empty-line-before.md
@@ -16,7 +16,7 @@ This rule ignores:
 - at-rules that are the very first node in the source
 - `@import` in Less.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/at-rule-name-case.md
+++ b/src/main/resources/docs/description/at-rule-name-case.md
@@ -11,7 +11,7 @@ Specify lowercase or uppercase for at-rules names.
 
 Only lowercase at-rule names are valid in SCSS.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix some of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix some of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/at-rule-name-space-after.md
+++ b/src/main/resources/docs/description/at-rule-name-space-after.md
@@ -9,7 +9,7 @@ Require a single space after at-rule names.
  * The space after at-rule names */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/at-rule-no-vendor-prefix.md
+++ b/src/main/resources/docs/description/at-rule-no-vendor-prefix.md
@@ -9,7 +9,7 @@ Disallow vendor prefixes for at-rules.
  * This prefix */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/at-rule-property-requirelist.md
+++ b/src/main/resources/docs/description/at-rule-property-requirelist.md
@@ -1,6 +1,6 @@
 # at-rule-property-requirelist
 
-**_Deprecated: Instead use the [`at-rule-property-required-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/at-rule-property-required-list/README.md) rule._**
+**_Deprecated: Instead use the [`at-rule-property-required-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/at-rule-property-required-list/README.md) rule._**
 
 Specify a list of required properties for an at-rule.
 

--- a/src/main/resources/docs/description/at-rule-semicolon-newline-after.md
+++ b/src/main/resources/docs/description/at-rule-semicolon-newline-after.md
@@ -19,7 +19,7 @@ This rule allows an end-of-line comment followed by a newline. For example:
 a {}
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/at-rule-whitelist.md
+++ b/src/main/resources/docs/description/at-rule-whitelist.md
@@ -1,6 +1,6 @@
 # at-rule-whitelist
 
-**_Deprecated: Instead use the [`at-rule-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/at-rule-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`at-rule-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/at-rule-allowed-list/README.md) rule._**
 
 Specify a list of allowed at-rules.
 

--- a/src/main/resources/docs/description/block-closing-brace-empty-line-before.md
+++ b/src/main/resources/docs/description/block-closing-brace-empty-line-before.md
@@ -12,7 +12,7 @@ a {
  * This line */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/block-closing-brace-newline-after.md
+++ b/src/main/resources/docs/description/block-closing-brace-newline-after.md
@@ -32,7 +32,7 @@ This rule allows a trailing semicolon after the closing brace of a block. For ex
 }
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/block-closing-brace-newline-before.md
+++ b/src/main/resources/docs/description/block-closing-brace-newline-before.md
@@ -10,7 +10,7 @@ Require a newline or disallow whitespace before the closing brace of blocks.
  * The newline before this brace */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/block-closing-brace-space-before.md
+++ b/src/main/resources/docs/description/block-closing-brace-space-before.md
@@ -9,7 +9,7 @@ a { color: pink; }
  * The space before this brace */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/block-opening-brace-newline-after.md
+++ b/src/main/resources/docs/description/block-opening-brace-newline-after.md
@@ -19,9 +19,9 @@ a { /* end-of-line comment */
 }
 ```
 
-Refer to [combining rules](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/rules/combine.md) for more information on using this rule with [`block-opening-brace-newline-before`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/block-opening-brace-newline-before/README.md) to disallow single-line rules.
+Refer to [combining rules](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/rules/combine.md) for more information on using this rule with [`block-opening-brace-newline-before`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/block-opening-brace-newline-before/README.md) to disallow single-line rules.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/block-opening-brace-newline-before.md
+++ b/src/main/resources/docs/description/block-opening-brace-newline-before.md
@@ -10,9 +10,9 @@ Require a newline or disallow whitespace before the opening brace of blocks.
  * The newline before this brace */
 ```
 
-Refer to [combining rules](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/rules/combine.md) for more information on using this rule with [`block-opening-brace-newline-after`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/block-opening-brace-newline-after/README.md) to disallow single-line rules.
+Refer to [combining rules](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/rules/combine.md) for more information on using this rule with [`block-opening-brace-newline-after`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/block-opening-brace-newline-after/README.md) to disallow single-line rules.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/block-opening-brace-space-after.md
+++ b/src/main/resources/docs/description/block-opening-brace-space-after.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace after the opening brace of blocks.
  * The space after this brace */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/block-opening-brace-space-before.md
+++ b/src/main/resources/docs/description/block-opening-brace-space-before.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace before the opening brace of blocks
  * The space before this brace */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/color-function-notation.md
+++ b/src/main/resources/docs/description/color-function-notation.md
@@ -13,7 +13,7 @@ Modern color-functions use a comma-free syntax because functions in CSS are used
 
 For legacy reasons, `rgb()` and `hsl()` also supports an alternate syntax that separates all of its arguments with commas. Also for legacy reasons, the `rgba()` and `hsla()` functions exist using the same comma-based syntax.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix some of the problems reported by this rule when the primary option is `"modern"`.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix some of the problems reported by this rule when the primary option is `"modern"`.
 
 ## Options
 

--- a/src/main/resources/docs/description/color-hex-case.md
+++ b/src/main/resources/docs/description/color-hex-case.md
@@ -9,7 +9,7 @@ a { color: #fff }
  * This hex color */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/color-hex-length.md
+++ b/src/main/resources/docs/description/color-hex-length.md
@@ -9,7 +9,7 @@ a { color: #fff }
  * This hex color */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/comment-empty-line-before.md
+++ b/src/main/resources/docs/description/comment-empty-line-before.md
@@ -18,7 +18,7 @@ This rule ignores:
 - single-line comments with `//` (when you're using a custom syntax that supports them)
 - comments within selector and value lists
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/comment-pattern.md
+++ b/src/main/resources/docs/description/comment-pattern.md
@@ -1,0 +1,38 @@
+# comment-pattern
+
+Specify a pattern for comments.
+
+<!-- prettier-ignore -->
+```css
+/*  comment */
+/** ↑
+ * The pattern of this */
+```
+
+## Options
+
+`regex|string`
+
+A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
+
+Given the string:
+
+```
+"foo .+"
+```
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+/*not starting with foo*/
+a { color: red; }
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+/*foo at the beginning*/
+a { color: red; }
+```

--- a/src/main/resources/docs/description/comment-whitespace-inside.md
+++ b/src/main/resources/docs/description/comment-whitespace-inside.md
@@ -13,7 +13,7 @@ Any number of asterisks are allowed at the beginning or end of the comment. So `
 
 **Caveat:** Comments within _selector and value lists_ are currently ignored.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/comment-word-blacklist.md
+++ b/src/main/resources/docs/description/comment-word-blacklist.md
@@ -1,6 +1,6 @@
 # comment-word-blacklist
 
-**_Deprecated: Instead use the [`comment-word-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/comment-word-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`comment-word-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/comment-word-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed words within comments.
 

--- a/src/main/resources/docs/description/custom-property-empty-line-before.md
+++ b/src/main/resources/docs/description/custom-property-empty-line-before.md
@@ -13,7 +13,7 @@ a {
  *                   This line */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-bang-space-after.md
+++ b/src/main/resources/docs/description/declaration-bang-space-after.md
@@ -9,7 +9,7 @@ a { color: pink !important; }
  * The space after this exclamation mark */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-bang-space-before.md
+++ b/src/main/resources/docs/description/declaration-bang-space-before.md
@@ -9,7 +9,7 @@ a { color: pink !important; }
  * The space before this exclamation mark */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-block-no-duplicate-custom-properties.md
+++ b/src/main/resources/docs/description/declaration-block-no-duplicate-custom-properties.md
@@ -1,0 +1,40 @@
+# declaration-block-no-duplicate-custom-properties
+
+Disallow duplicate custom properties within declaration blocks.
+
+<!-- prettier-ignore -->
+```css
+a { --custom-property: pink; --custom-property: orange; }
+/** ↑                        ↑
+ * These duplicated custom properties */
+```
+
+This rule is case-sensitive.
+
+## Options
+
+### `true`
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { --custom-property: pink; --custom-property: orange; }
+```
+
+<!-- prettier-ignore -->
+```css
+a { --custom-property: pink; background: orange; --custom-property: orange }
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { --custom-property: pink; }
+```
+
+<!-- prettier-ignore -->
+```css
+a { --custom-property: pink; --cUstOm-prOpErtY: orange; }
+```

--- a/src/main/resources/docs/description/declaration-block-semicolon-newline-after.md
+++ b/src/main/resources/docs/description/declaration-block-semicolon-newline-after.md
@@ -29,7 +29,7 @@ a {
 }
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-block-semicolon-space-after.md
+++ b/src/main/resources/docs/description/declaration-block-semicolon-space-after.md
@@ -16,7 +16,7 @@ This rule ignores:
 
 Use the `block-closing-brace-*-before` rules to control the whitespace between the last semicolon and the closing brace instead.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-block-semicolon-space-before.md
+++ b/src/main/resources/docs/description/declaration-block-semicolon-space-before.md
@@ -11,7 +11,7 @@ a { color: pink; }
 
 This rule ignores semicolons that are preceded by Less mixins.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-block-trailing-semicolon.md
+++ b/src/main/resources/docs/description/declaration-block-trailing-semicolon.md
@@ -17,7 +17,7 @@ This rule ignores:
 - trailing `//` comments
 - declaration blocks containing nested (at-)rules
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 
@@ -87,4 +87,22 @@ a { color: pink }
 <!-- prettier-ignore -->
 ```css
 a { background: orange; color: pink }
+```
+
+## Optional secondary options
+
+### `ignore: ["single-declaration"]`
+
+Ignore declaration blocks that contain a single declaration.
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { color: pink }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: pink; }
 ```

--- a/src/main/resources/docs/description/declaration-colon-newline-after.md
+++ b/src/main/resources/docs/description/declaration-colon-newline-after.md
@@ -13,7 +13,7 @@ a {
  * The newline after this colon */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-colon-space-after.md
+++ b/src/main/resources/docs/description/declaration-colon-space-after.md
@@ -9,7 +9,7 @@ a { color: pink }
  * The space after this colon */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-colon-space-before.md
+++ b/src/main/resources/docs/description/declaration-colon-space-before.md
@@ -9,7 +9,7 @@ a { color :pink }
  * The space before this colon */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-empty-line-before.md
+++ b/src/main/resources/docs/description/declaration-empty-line-before.md
@@ -13,9 +13,9 @@ a {
  *      This line */
 ```
 
-This rule only applies to standard property declarations. Use the [`custom-property-empty-line-before`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/custom-property-empty-line-before/README.md) rule for custom property declarations.
+This rule only applies to standard property declarations. Use the [`custom-property-empty-line-before`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/custom-property-empty-line-before/README.md) rule for custom property declarations.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/declaration-property-unit-allowed-list.md
+++ b/src/main/resources/docs/description/declaration-property-unit-allowed-list.md
@@ -83,3 +83,37 @@ a { animation-duration: 5s; }
 ```css
 a { line-height: 1; }
 ```
+
+## Optional secondary options
+
+### `ignore: ["inside-function"]`
+
+Ignore units that are inside a function.
+
+For example, given:
+
+```
+{
+  "/^border/": ["px"],
+  "/^background/": ["%"],
+},
+{
+  "ignore": ["inside-function"],
+},
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a {
+  border: 1px solid hsla(162deg, 51%, 35%, 0.8);
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a {
+  background-image: linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8));
+}
+```

--- a/src/main/resources/docs/description/declaration-property-unit-blacklist.md
+++ b/src/main/resources/docs/description/declaration-property-unit-blacklist.md
@@ -1,6 +1,6 @@
 # declaration-property-unit-blacklist
 
-**_Deprecated: Instead use the [`declaration-property-unit-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/declaration-property-unit-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`declaration-property-unit-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/declaration-property-unit-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed property and unit pairs within declarations.
 

--- a/src/main/resources/docs/description/declaration-property-unit-whitelist.md
+++ b/src/main/resources/docs/description/declaration-property-unit-whitelist.md
@@ -1,6 +1,6 @@
 # declaration-property-unit-whitelist
 
-**_Deprecated: Instead use the [`declaration-property-unit-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/declaration-property-unit-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`declaration-property-unit-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/declaration-property-unit-allowed-list/README.md) rule._**
 
 Specify a list of allowed property and unit pairs within declarations.
 

--- a/src/main/resources/docs/description/declaration-property-value-allowed-list.md
+++ b/src/main/resources/docs/description/declaration-property-value-allowed-list.md
@@ -11,7 +11,7 @@ a { text-transform: uppercase; }
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": ["array", "of", "values"], "unprefixed-property-name": ["/regex/", "non-regex"] }`
+`object`: `{ "unprefixed-property-name": ["array", "of", "values"], "unprefixed-property-name": ["/regex/", "non-regex", /regex/] }`
 
 If a property name is found in the object, only the listed property values are allowed. This rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
 
@@ -62,11 +62,6 @@ The following patterns are _not_ considered violations:
 
 <!-- prettier-ignore -->
 ```css
-a { color: pink; }
-```
-
-<!-- prettier-ignore -->
-```css
 a { whitespace: nowrap; }
 ```
 
@@ -88,9 +83,4 @@ a { color: green; }
 <!-- prettier-ignore -->
 ```css
 a { background-color: green; }
-```
-
-<!-- prettier-ignore -->
-```css
-a { background: pink; }
 ```

--- a/src/main/resources/docs/description/declaration-property-value-blacklist.md
+++ b/src/main/resources/docs/description/declaration-property-value-blacklist.md
@@ -1,6 +1,6 @@
 # declaration-property-value-blacklist
 
-**_Deprecated: Instead use the [`declaration-property-value-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/declaration-property-value-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`declaration-property-value-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/declaration-property-value-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed property and value pairs within declarations.
 

--- a/src/main/resources/docs/description/declaration-property-value-whitelist.md
+++ b/src/main/resources/docs/description/declaration-property-value-whitelist.md
@@ -1,6 +1,6 @@
 # declaration-property-value-whitelist
 
-**_Deprecated: Instead use the [`declaration-property-value-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/declaration-property-value-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`declaration-property-value-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/declaration-property-value-allowed-list/README.md) rule._**
 
 Specify a list of allowed property and value pairs within declarations.
 

--- a/src/main/resources/docs/description/description.json
+++ b/src/main/resources/docs/description/description.json
@@ -300,6 +300,13 @@
     "description" : "no-missing-end-of-source-newline"
   } ]
 }, {
+  "patternId" : "selector-attribute-name-disallowed-list",
+  "title" : "Specify a list of disallowed attribute names.",
+  "parameters" : [ {
+    "name" : "selector-attribute-name-disallowed-list",
+    "description" : "selector-attribute-name-disallowed-list"
+  } ]
+}, {
   "patternId" : "value-list-comma-space-after",
   "title" : "Require a single space or disallow whitespace after the commas of value lists.",
   "parameters" : [ {
@@ -312,6 +319,13 @@
   "parameters" : [ {
     "name" : "selector-pseudo-class-disallowed-list",
     "description" : "selector-pseudo-class-disallowed-list"
+  } ]
+}, {
+  "patternId" : "selector-disallowed-list",
+  "title" : "Specify a list of disallowed selectors.",
+  "parameters" : [ {
+    "name" : "selector-disallowed-list",
+    "description" : "selector-disallowed-list"
   } ]
 }, {
   "patternId" : "selector-id-pattern",
@@ -592,6 +606,13 @@
   "parameters" : [ {
     "name" : "no-empty-first-line",
     "description" : "no-empty-first-line"
+  } ]
+}, {
+  "patternId" : "no-invalid-position-at-import-rule",
+  "title" : "Disallow invalid position `@import` rules within a stylesheet.",
+  "parameters" : [ {
+    "name" : "no-invalid-position-at-import-rule",
+    "description" : "no-invalid-position-at-import-rule"
   } ]
 }, {
   "patternId" : "selector-pseudo-class-no-unknown",
@@ -1014,6 +1035,13 @@
     "description" : "media-feature-name-case"
   } ]
 }, {
+  "patternId" : "no-irregular-whitespace",
+  "title" : "Disallow irregular whitespaces.",
+  "parameters" : [ {
+    "name" : "no-irregular-whitespace",
+    "description" : "no-irregular-whitespace"
+  } ]
+}, {
   "patternId" : "media-query-list-comma-space-after",
   "title" : "Require a single space or disallow whitespace after the commas of media query lists.",
   "parameters" : [ {
@@ -1028,11 +1056,25 @@
     "description" : "custom-property-empty-line-before"
   } ]
 }, {
+  "patternId" : "declaration-block-no-duplicate-custom-properties",
+  "title" : "Disallow duplicate custom properties within declaration blocks.",
+  "parameters" : [ {
+    "name" : "declaration-block-no-duplicate-custom-properties",
+    "description" : "declaration-block-no-duplicate-custom-properties"
+  } ]
+}, {
   "patternId" : "block-closing-brace-newline-before",
   "title" : "Require a newline or disallow whitespace before the closing brace of blocks.",
   "parameters" : [ {
     "name" : "block-closing-brace-newline-before",
     "description" : "block-closing-brace-newline-before"
+  } ]
+}, {
+  "patternId" : "comment-pattern",
+  "title" : "Specify a pattern for comments.",
+  "parameters" : [ {
+    "name" : "comment-pattern",
+    "description" : "comment-pattern"
   } ]
 }, {
   "patternId" : "at-rule-whitelist",
@@ -1376,6 +1418,13 @@
   "parameters" : [ {
     "name" : "selector-max-empty-lines",
     "description" : "selector-max-empty-lines"
+  } ]
+}, {
+  "patternId" : "named-grid-areas-no-invalid",
+  "title" : "Disallow invalid named grid areas.",
+  "parameters" : [ {
+    "name" : "named-grid-areas-no-invalid",
+    "description" : "named-grid-areas-no-invalid"
   } ]
 }, {
   "patternId" : "at-rule-name-space-after",

--- a/src/main/resources/docs/description/font-family-no-missing-generic-family-keyword.md
+++ b/src/main/resources/docs/description/font-family-no-missing-generic-family-keyword.md
@@ -54,6 +54,16 @@ a { font: inherit; }
 a { font: caption; }
 ```
 
+<!-- prettier-ignore -->
+```css
+a { font-family: var(--font-family-common); }
+```
+
+<!-- prettier-ignore -->
+```css
+a { font-family: Helvetica, var(--font-family-common); }
+```
+
 ## Optional secondary options
 
 ### `ignoreFontFamilies: ["/regex/", /regex/, "string"]`

--- a/src/main/resources/docs/description/function-blacklist.md
+++ b/src/main/resources/docs/description/function-blacklist.md
@@ -1,6 +1,6 @@
 # function-blacklist
 
-**_Deprecated: Instead use the [`function-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/function-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`function-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/function-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed functions.
 

--- a/src/main/resources/docs/description/function-comma-newline-after.md
+++ b/src/main/resources/docs/description/function-comma-newline-after.md
@@ -10,7 +10,7 @@ a { transform: translate(1,
  *             These commas */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/function-comma-newline-before.md
+++ b/src/main/resources/docs/description/function-comma-newline-before.md
@@ -10,7 +10,7 @@ Require a newline or disallow whitespace before the commas of functions.
  * This comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/function-comma-space-after.md
+++ b/src/main/resources/docs/description/function-comma-space-after.md
@@ -9,7 +9,7 @@ a { transform: translate(1, 1) }
  * The space after this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/function-comma-space-before.md
+++ b/src/main/resources/docs/description/function-comma-space-before.md
@@ -9,7 +9,7 @@ a { transform: translate(1 ,1) }
  * The space before this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/function-max-empty-lines.md
+++ b/src/main/resources/docs/description/function-max-empty-lines.md
@@ -18,7 +18,7 @@ a {
  *            These lines */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/function-name-case.md
+++ b/src/main/resources/docs/description/function-name-case.md
@@ -11,7 +11,7 @@ a { width: calc(5% - 10em); }
 
 Camel case function names, e.g. `translateX`, are accounted for when the `lower` option is used.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/function-parentheses-newline-inside.md
+++ b/src/main/resources/docs/description/function-parentheses-newline-inside.md
@@ -14,7 +14,7 @@ Require a newline or disallow whitespace on the inside of the parentheses of fun
  * The newline inside these two parentheses */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/function-parentheses-space-inside.md
+++ b/src/main/resources/docs/description/function-parentheses-space-inside.md
@@ -9,7 +9,7 @@ a { transform: translate( 1, 1 ); }
  * The space inside these two parentheses */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/function-url-scheme-blacklist.md
+++ b/src/main/resources/docs/description/function-url-scheme-blacklist.md
@@ -1,6 +1,6 @@
 # function-url-scheme-blacklist
 
-**_Deprecated: Instead use the [`function-url-scheme-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/function-url-scheme-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`function-url-scheme-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/function-url-scheme-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed URL schemes.
 

--- a/src/main/resources/docs/description/function-url-scheme-whitelist.md
+++ b/src/main/resources/docs/description/function-url-scheme-whitelist.md
@@ -1,6 +1,6 @@
 # function-url-scheme-whitelist
 
-**_Deprecated: Instead use the [`function-url-scheme-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/function-url-scheme-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`function-url-scheme-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/function-url-scheme-allowed-list/README.md) rule._**
 
 Specify a list of allowed URL schemes.
 

--- a/src/main/resources/docs/description/function-whitelist.md
+++ b/src/main/resources/docs/description/function-whitelist.md
@@ -1,6 +1,6 @@
 # function-whitelist
 
-**_Deprecated: Instead use the [`function-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/function-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`function-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/function-allowed-list/README.md) rule._**
 
 Specify a list of allowed functions.
 

--- a/src/main/resources/docs/description/function-whitespace-after.md
+++ b/src/main/resources/docs/description/function-whitespace-after.md
@@ -11,7 +11,7 @@ a { transform: translate(1, 1) scale(3); }
 
 This rule does not check for space immediately after `)` if the very next character is `,`, `)`, `/` or `}`, allowing some of the patterns exemplified below.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/hue-degree-notation.md
+++ b/src/main/resources/docs/description/hue-degree-notation.md
@@ -11,7 +11,7 @@ Specify number or angle notation for degree hues.
 
 Because hues are so often given in degrees, a hue can also be given as a number, which is interpreted as a number of degrees.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/indentation.md
+++ b/src/main/resources/docs/description/indentation.md
@@ -14,7 +14,7 @@ Specify indentation.
  * The indentation at these three points */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/keyframe-declaration-no-important.md
+++ b/src/main/resources/docs/description/keyframe-declaration-no-important.md
@@ -4,55 +4,30 @@ Disallow `!important` within keyframe declarations.
 
 <!-- prettier-ignore -->
 ```css
-@keyframes important2 {
-  from { margin: 10px }
-  to { margin: 20px !important }
-}                /* ↑ */
-/**                 ↑
-*     This !important */
+@keyframes foo {
+  from { opacity: 0 }
+  to { opacity: 1 !important }
+}              /* ↑ */
+/**               ↑
+*   This !important */
 ```
 
-Using `!important` within keyframes declarations is completely ignored in some browsers:
-[MDN - !important in a keyframe](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes#!important_in_a_keyframe)
+Using `!important` within keyframes declarations is [completely ignored in some browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes#!important_in_a_keyframe).
 
 ## Options
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns is considered a violation:
 
 <!-- prettier-ignore -->
 ```css
-@keyframes important1 {
+@keyframes foo {
   from {
-    margin-top: 50px;
+    opacity: 0;
   }
   to {
-    margin-top: 100px !important;
-  }
-}
-```
-
-<!-- prettier-ignore -->
-```css
-@keyframes important1 {
-  from {
-    margin-top: 50px;
-  }
-  to {
-    margin-top: 100px!important;
-  }
-}
-```
-
-<!-- prettier-ignore -->
-```css
-@keyframes important1 {
-  from {
-    margin-top: 50px;
-  }
-  to {
-    margin-top: 100px ! important;
+    opacity: 1 !important;
   }
 }
 ```
@@ -61,17 +36,17 @@ The following patterns are _not_ considered violations:
 
 <!-- prettier-ignore -->
 ```css
-a { color: pink !important; }
+@keyframes foo {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
 ```
 
 <!-- prettier-ignore -->
 ```css
-@keyframes important1 {
-  from {
-    margin-top: 50px;
-  }
-  to {
-    margin-top: 100px;
-  }
-}
+a { color: pink !important; }
 ```

--- a/src/main/resources/docs/description/length-zero-no-unit.md
+++ b/src/main/resources/docs/description/length-zero-no-unit.md
@@ -11,9 +11,9 @@ a { top: 0px; }
 
 _Lengths_ refer to distance measurements. A length is a _dimension_, which is a _number_ immediately followed by a _unit identifier_. However, for zero lengths the unit identifier is optional. The length units are: `em`, `ex`, `ch`, `vw`, `vh`, `cm`, `mm`, `in`, `pt`, `pc`, `px`, `rem`, `vmin`, and `vmax`.
 
-This rule ignores lengths within math functions (e.g. `calc`) in favor of the [`function-calc-no-invalid`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/function-calc-no-invalid/README.md) rule.
+This rule ignores lengths within math functions (e.g. `calc`) in favor of the [`function-calc-no-invalid`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/function-calc-no-invalid/README.md) rule.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/linebreaks.md
+++ b/src/main/resources/docs/description/linebreaks.md
@@ -2,7 +2,7 @@
 
 Specify unix or windows linebreaks.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/max-empty-lines.md
+++ b/src/main/resources/docs/description/max-empty-lines.md
@@ -12,7 +12,7 @@ a {} /* ↑ */
  * These lines */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-feature-colon-space-after.md
+++ b/src/main/resources/docs/description/media-feature-colon-space-after.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace after the colon in media features.
  * The space after this colon */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-feature-colon-space-before.md
+++ b/src/main/resources/docs/description/media-feature-colon-space-before.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace before the colon in media features
  * The space before this colon */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-feature-name-blacklist.md
+++ b/src/main/resources/docs/description/media-feature-name-blacklist.md
@@ -1,6 +1,6 @@
 # media-feature-name-blacklist
 
-**_Deprecated: Instead use the [`media-feature-name-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/media-feature-name-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`media-feature-name-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/media-feature-name-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed media feature names.
 

--- a/src/main/resources/docs/description/media-feature-name-case.md
+++ b/src/main/resources/docs/description/media-feature-name-case.md
@@ -9,7 +9,7 @@ Specify lowercase or uppercase for media feature names.
  * This media feature name */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-feature-name-no-vendor-prefix.md
+++ b/src/main/resources/docs/description/media-feature-name-no-vendor-prefix.md
@@ -11,7 +11,7 @@ Disallow vendor prefixes for media feature names.
 
 Right now this rule simply checks for prefixed _resolutions_.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-feature-name-value-whitelist.md
+++ b/src/main/resources/docs/description/media-feature-name-value-whitelist.md
@@ -1,6 +1,6 @@
 # media-feature-name-value-whitelist
 
-**_Deprecated: Instead use the [`media-feature-name-value-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/media-feature-name-value-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`media-feature-name-value-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/media-feature-name-value-allowed-list/README.md) rule._**
 
 Specify a list of allowed media feature name and value pairs.
 

--- a/src/main/resources/docs/description/media-feature-name-whitelist.md
+++ b/src/main/resources/docs/description/media-feature-name-whitelist.md
@@ -1,6 +1,6 @@
 # media-feature-name-whitelist
 
-**_Deprecated: Instead use the [`media-feature-name-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/media-feature-name-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`media-feature-name-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/media-feature-name-allowed-list/README.md) rule._**
 
 Specify a list of allowed media feature names.
 

--- a/src/main/resources/docs/description/media-feature-parentheses-space-inside.md
+++ b/src/main/resources/docs/description/media-feature-parentheses-space-inside.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace on the inside of the parentheses w
  * The space inside these two parentheses */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-feature-range-operator-space-after.md
+++ b/src/main/resources/docs/description/media-feature-range-operator-space-after.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace after the range operator in media 
  * The space after this operator */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-feature-range-operator-space-before.md
+++ b/src/main/resources/docs/description/media-feature-range-operator-space-before.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace before the range operator in media
  * The space before this operator */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-query-list-comma-newline-after.md
+++ b/src/main/resources/docs/description/media-query-list-comma-newline-after.md
@@ -10,7 +10,7 @@ Require a newline or disallow whitespace after the commas of media query lists.
  *            These commas */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-query-list-comma-space-after.md
+++ b/src/main/resources/docs/description/media-query-list-comma-space-after.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace after the commas of media query li
  * The space after this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/media-query-list-comma-space-before.md
+++ b/src/main/resources/docs/description/media-query-list-comma-space-before.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace before the commas of media query l
  * The space before this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/named-grid-areas-no-invalid.md
+++ b/src/main/resources/docs/description/named-grid-areas-no-invalid.md
@@ -1,0 +1,50 @@
+# named-grid-areas-no-invalid
+
+Disallow invalid named grid areas.
+
+<!-- prettier-ignore -->
+```css
+a { grid-template-areas:
+      "a a a"
+      "b b b"; }
+/**   ↑
+ *  This named grid area */
+```
+
+For a named grid area to be valid, all strings must define:
+
+- the same number of cell tokens
+- at least one cell token
+
+And all named grid areas that spans multiple grid cells must form a single filled-in rectangle.
+
+## Options
+
+### `true`
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { grid-template-areas: "" }
+```
+
+<!-- prettier-ignore -->
+```css
+a { grid-template-areas: "a a a"
+                         "b b b b"; }
+```
+
+<!-- prettier-ignore -->
+```css
+a { grid-template-areas: "a a a"
+                         "b b a"; }
+```
+
+The following pattern is _not_ considered a violation:
+
+<!-- prettier-ignore -->
+```css
+a { grid-template-areas: "a a a"
+                         "b b b"; }
+```

--- a/src/main/resources/docs/description/no-empty-first-line.md
+++ b/src/main/resources/docs/description/no-empty-first-line.md
@@ -10,9 +10,9 @@ Disallow empty first lines.
     a { color: pink; }
 ```
 
-This rule ignores empty sources. Use the [`no-empty-source`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/no-empty-source/README.md) rule to disallow these.
+This rule ignores empty sources. Use the [`no-empty-source`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/no-empty-source/README.md) rule to disallow these.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/no-eol-whitespace.md
+++ b/src/main/resources/docs/description/no-eol-whitespace.md
@@ -9,7 +9,7 @@ a { color: pink; }···
  *  This whitespace */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/no-extra-semicolons.md
+++ b/src/main/resources/docs/description/no-extra-semicolons.md
@@ -11,7 +11,7 @@ a { color: pink;; }
 
 This rule ignores semicolons after Less mixins.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/no-invalid-position-at-import-rule.md
+++ b/src/main/resources/docs/description/no-invalid-position-at-import-rule.md
@@ -1,0 +1,51 @@
+# no-invalid-position-at-import-rule
+
+Disallow invalid position `@import` rules within a stylesheet.
+
+<!-- prettier-ignore -->
+```css
+a {}
+@import 'foo.css';
+/** ↑
+  * This @import */
+```
+
+Any `@import` rules must precede all other valid at-rules and style rules in a stylesheet (ignoring `@charset`), or else the `@import` rule is invalid.
+
+## Options
+
+### `true`
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a {}
+@import 'foo.css';
+```
+
+<!-- prettier-ignore -->
+```css
+@media print {}
+@import 'foo.css';
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+@import 'foo.css';
+a {}
+```
+
+<!-- prettier-ignore -->
+```css
+/* some comment */
+@import 'foo.css';
+```
+
+<!-- prettier-ignore -->
+```css
+@charset 'utf-8';
+@import 'foo.css';
+```

--- a/src/main/resources/docs/description/no-irregular-whitespace.md
+++ b/src/main/resources/docs/description/no-irregular-whitespace.md
@@ -1,0 +1,57 @@
+# no-irregular-whitespace
+
+Disallow irregular whitespaces.
+
+<!-- prettier-ignore -->
+```css
+    .firstClass .secondClass {}
+/**            ↑
+ * Irregular whitespace. Selector would fail to match '.firstClass' */
+```
+
+## Options
+
+### `true`
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+.firstClass .secondClass {}
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+.firstClass .secondClass { /* Writing comments with irregular whitespaces */ }
+```
+
+## Unicode reference of irregular whitespaces
+
+```
+\u000B - Line Tabulation (\v) - <VT>
+\u000C - Form Feed (\f) - <FF>
+\u00A0 - No-Break Space - <NBSP>
+\u0085 - Next Line
+\u1680 - Ogham Space Mark
+\u180E - Mongolian Vowel Separator - <MVS>
+\uFEFF - Zero Width No-Break Space - <BOM>
+\u2000 - En Quad
+\u2001 - Em Quad
+\u2002 - En Space - <ENSP>
+\u2003 - Em Space - <EMSP>
+\u2004 - Tree-Per-Em
+\u2005 - Four-Per-Em
+\u2006 - Six-Per-Em
+\u2007 - Figure Space
+\u2008 - Punctuation Space - <PUNCSP>
+\u2009 - Thin Space
+\u200A - Hair Space
+\u200B - Zero Width Space - <ZWSP>
+\u2028 - Line Separator
+\u2029 - Paragraph Separator
+\u202F - Narrow No-Break Space
+\u205F - Medium Mathematical Space
+\u3000 - Ideographic Space
+```

--- a/src/main/resources/docs/description/no-missing-end-of-source-newline.md
+++ b/src/main/resources/docs/description/no-missing-end-of-source-newline.md
@@ -12,7 +12,7 @@ Disallow missing end-of-source newlines.
 
 Completely empty files are not considered violations.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/number-leading-zero.md
+++ b/src/main/resources/docs/description/number-leading-zero.md
@@ -11,7 +11,7 @@ a { line-height: 0.5; }
 
 This rule ignores mixin parameters in Less.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/number-no-trailing-zeros.md
+++ b/src/main/resources/docs/description/number-no-trailing-zeros.md
@@ -9,7 +9,7 @@ a { top: 0.5000px; bottom: 1.0px; }
  *        These trailing zeros */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix some of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix some of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/property-blacklist.md
+++ b/src/main/resources/docs/description/property-blacklist.md
@@ -1,6 +1,6 @@
 # property-blacklist
 
-**_Deprecated: Instead use the [`property-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/property-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`property-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/property-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed properties.
 

--- a/src/main/resources/docs/description/property-case.md
+++ b/src/main/resources/docs/description/property-case.md
@@ -9,7 +9,7 @@ Specify lowercase or uppercase for properties.
  * This property */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/property-no-unknown.md
+++ b/src/main/resources/docs/description/property-no-unknown.md
@@ -127,6 +127,27 @@ The following patterns are _not_ considered violations:
 }
 ```
 
+### `ignoreAtRules: ["/regex/", /regex/, "string"]`
+
+Ignores properties nested within specified at-rules.
+
+Given:
+
+```
+["supports"]
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+@supports (display: grid) {
+  a {
+    my-property: 1;
+  }
+}
+```
+
 ### `checkPrefixed: true | false` (default: `false`)
 
 If `true`, this rule will check vendor-prefixed properties.

--- a/src/main/resources/docs/description/property-no-vendor-prefix.md
+++ b/src/main/resources/docs/description/property-no-vendor-prefix.md
@@ -11,7 +11,7 @@ a { -webkit-transform: scale(1); }
 
 This rule does not blanketly condemn vendor prefixes. Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should cause a violation or not. _If you've included a vendor prefixed property that has a standard alternative, one that Autoprefixer could take care of for you, this rule will complain about it_. If, however, you use a non-standard vendor-prefixed property, one that Autoprefixer would ignore and could not provide (such as `-webkit-touch-callout`), this rule will ignore it.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/property-whitelist.md
+++ b/src/main/resources/docs/description/property-whitelist.md
@@ -1,6 +1,6 @@
 # property-whitelist
 
-**_Deprecated: Instead use the [`property-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/property-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`property-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/property-allowed-list/README.md) rule._**
 
 Specify a list of allowed properties.
 

--- a/src/main/resources/docs/description/rule-empty-line-before.md
+++ b/src/main/resources/docs/description/rule-empty-line-before.md
@@ -13,7 +13,7 @@ b {}  /* ↑ */
 
 This rule ignores rules that are the very first node in a source.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-attribute-brackets-space-inside.md
+++ b/src/main/resources/docs/description/selector-attribute-brackets-space-inside.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace on the inside of the brackets with
  * The space inside these two brackets */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-attribute-name-disallowed-list.md
+++ b/src/main/resources/docs/description/selector-attribute-name-disallowed-list.md
@@ -1,0 +1,54 @@
+# selector-attribute-name-disallowed-list
+
+Specify a list of disallowed attribute names.
+
+<!-- prettier-ignore -->
+```css
+    [class~="foo"] {}
+/**  ↑
+ * This name */
+```
+
+## Options
+
+`array|string|regex`: `["array", "of", /names/ or "regex"]|"name"|/regex/`
+
+Given:
+
+```
+["class", "id", "/^data-/"]
+```
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+[class*="foo"] {}
+```
+
+<!-- prettier-ignore -->
+```css
+[id~="bar"] {}
+```
+
+<!-- prettier-ignore -->
+```css
+[data-foo*="bar"] {}
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+[lang~="en-us"] {}
+```
+
+<!-- prettier-ignore -->
+```css
+[target="_blank"] {}
+```
+
+<!-- prettier-ignore -->
+```css
+[href$=".bar"] {}
+```

--- a/src/main/resources/docs/description/selector-attribute-operator-blacklist.md
+++ b/src/main/resources/docs/description/selector-attribute-operator-blacklist.md
@@ -1,6 +1,6 @@
 # selector-attribute-operator-blacklist
 
-**_Deprecated: Instead use the [`selector-attribute-operator-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/selector-attribute-operator-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`selector-attribute-operator-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/selector-attribute-operator-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed attribute operators.
 

--- a/src/main/resources/docs/description/selector-attribute-operator-space-after.md
+++ b/src/main/resources/docs/description/selector-attribute-operator-space-after.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace after operators within attribute s
  * The space after operator */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-attribute-operator-space-before.md
+++ b/src/main/resources/docs/description/selector-attribute-operator-space-before.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace before operators within attribute 
  * The space before operator */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-attribute-operator-whitelist.md
+++ b/src/main/resources/docs/description/selector-attribute-operator-whitelist.md
@@ -1,6 +1,6 @@
 # selector-attribute-operator-whitelist
 
-**_Deprecated: Instead use the [`selector-attribute-operator-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/selector-attribute-operator-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`selector-attribute-operator-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/selector-attribute-operator-allowed-list/README.md) rule._**
 
 Specify a list of allowed attribute operators.
 

--- a/src/main/resources/docs/description/selector-attribute-quotes.md
+++ b/src/main/resources/docs/description/selector-attribute-quotes.md
@@ -9,6 +9,8 @@ Require or disallow quotes for attribute values.
  * These quotes */
 ```
 
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/src/main/resources/docs/description/selector-combinator-blacklist.md
+++ b/src/main/resources/docs/description/selector-combinator-blacklist.md
@@ -1,6 +1,6 @@
 # selector-combinator-blacklist
 
-**_Deprecated: Instead use the [`selector-combinator-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/selector-combinator-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`selector-combinator-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/selector-combinator-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed combinators.
 

--- a/src/main/resources/docs/description/selector-combinator-space-after.md
+++ b/src/main/resources/docs/description/selector-combinator-space-after.md
@@ -15,7 +15,7 @@ The descendant combinator is _not_ checked by this rule.
 
 Also, `+` and `-` signs within `:nth-*()` arguments are not checked (e.g. `a:nth-child(2n+1)`).
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-combinator-space-before.md
+++ b/src/main/resources/docs/description/selector-combinator-space-before.md
@@ -15,7 +15,7 @@ The descendant combinator is _not_ checked by this rule.
 
 Also, `+` and `-` signs within `:nth-*()` arguments are not checked (e.g. `a:nth-child(2n+1)`).
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-combinator-whitelist.md
+++ b/src/main/resources/docs/description/selector-combinator-whitelist.md
@@ -1,6 +1,6 @@
 # selector-combinator-whitelist
 
-**_Deprecated: Instead use the [`selector-combinator-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/selector-combinator-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`selector-combinator-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/selector-combinator-allowed-list/README.md) rule._**
 
 Specify a list of allowed combinators.
 

--- a/src/main/resources/docs/description/selector-descendant-combinator-no-non-space.md
+++ b/src/main/resources/docs/description/selector-descendant-combinator-no-non-space.md
@@ -11,7 +11,7 @@ Disallow non-space characters for descendant combinators of selectors.
 
 This rule ensures that only a single space is used and ensures no tabs, newlines, nor multiple spaces are used for descendant combinators of selectors.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
 
 This rule currently ignores selectors containing comments.
 

--- a/src/main/resources/docs/description/selector-disallowed-list.md
+++ b/src/main/resources/docs/description/selector-disallowed-list.md
@@ -1,0 +1,68 @@
+# selector-disallowed-list
+
+Specify a list of disallowed selectors.
+
+<!-- prettier-ignore -->
+```css
+    .foo > .bar
+/** ↑
+ * This is selector */
+```
+
+## Options
+
+`array|string|regexp`: `["array", "of", "selectors", /or/, "/regex/"]|"selector"|"/regex/"`
+
+If a string is surrounded with `"/"` (e.g. `"/\.foo/"`), it is interpreted as a regular expression.
+
+Given:
+
+```
+["a > .foo", /\[data-.+]/]
+```
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a > .foo {}
+```
+
+<!-- prettier-ignore -->
+```css
+a[data-auto="1"] {}
+```
+
+<!-- prettier-ignore -->
+```css
+.foo, [data-auto="1"] {}
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+.foo {}
+```
+
+<!-- prettier-ignore -->
+```css
+a
+>
+.foo {}
+```
+
+<!-- prettier-ignore -->
+```css
+.bar > a > .foo {}
+```
+
+<!-- prettier-ignore -->
+```css
+.data-auto {}
+```
+
+<!-- prettier-ignore -->
+```css
+a[href] {}
+```

--- a/src/main/resources/docs/description/selector-list-comma-newline-after.md
+++ b/src/main/resources/docs/description/selector-list-comma-newline-after.md
@@ -18,7 +18,7 @@ a, /* comment */
 b { color: pink; }
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-list-comma-newline-before.md
+++ b/src/main/resources/docs/description/selector-list-comma-newline-before.md
@@ -10,7 +10,7 @@ Require a newline or disallow whitespace before the commas of selector lists.
  * The newline before this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-list-comma-space-after.md
+++ b/src/main/resources/docs/description/selector-list-comma-space-after.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace after the commas of selector lists
  * The space after this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-list-comma-space-before.md
+++ b/src/main/resources/docs/description/selector-list-comma-space-before.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace before the commas of selector list
  * The space before this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-max-empty-lines.md
+++ b/src/main/resources/docs/description/selector-max-empty-lines.md
@@ -13,7 +13,7 @@ b {        /* ↑ */
  *        This empty line */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-no-vendor-prefix.md
+++ b/src/main/resources/docs/description/selector-no-vendor-prefix.md
@@ -11,7 +11,7 @@ input::-moz-placeholder {}
 
 This rule does not blanketly condemn vendor prefixes. Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should cause a violation or not. _If you've included a vendor prefixed selector that has a standard alternative, one that Autoprefixer could take care of for you, this rule will complain about it_. If, however, you use a non-standard vendor-prefixed selector, one that Autoprefixer would ignore and could not provide, this rule will ignore it.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-pseudo-class-blacklist.md
+++ b/src/main/resources/docs/description/selector-pseudo-class-blacklist.md
@@ -1,6 +1,6 @@
 # selector-pseudo-class-blacklist
 
-**_Deprecated: Instead use the [`selector-pseudo-class-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/selector-pseudo-class-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`selector-pseudo-class-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/selector-pseudo-class-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed pseudo-class selectors.
 

--- a/src/main/resources/docs/description/selector-pseudo-class-case.md
+++ b/src/main/resources/docs/description/selector-pseudo-class-case.md
@@ -9,7 +9,7 @@ Specify lowercase or uppercase for pseudo-class selectors.
  * This pseudo-class selector */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-pseudo-class-parentheses-space-inside.md
+++ b/src/main/resources/docs/description/selector-pseudo-class-parentheses-space-inside.md
@@ -9,7 +9,7 @@ input:not( [type="submit"] ) {}
  * The space inside these two parentheses */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule. It won't fix pseudo elements containing comments.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule. It won't fix pseudo elements containing comments.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-pseudo-class-whitelist.md
+++ b/src/main/resources/docs/description/selector-pseudo-class-whitelist.md
@@ -1,6 +1,6 @@
 # selector-pseudo-class-whitelist
 
-**_Deprecated: Instead use the [`selector-pseudo-class-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/selector-pseudo-class-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`selector-pseudo-class-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/selector-pseudo-class-allowed-list/README.md) rule._**
 
 Specify a list of allowed pseudo-class selectors.
 

--- a/src/main/resources/docs/description/selector-pseudo-element-blacklist.md
+++ b/src/main/resources/docs/description/selector-pseudo-element-blacklist.md
@@ -1,6 +1,6 @@
 # selector-pseudo-element-blacklist
 
-**_Deprecated: Instead use the [`selector-pseudo-element-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/selector-pseudo-element-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`selector-pseudo-element-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/selector-pseudo-element-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed pseudo-element selectors.
 

--- a/src/main/resources/docs/description/selector-pseudo-element-case.md
+++ b/src/main/resources/docs/description/selector-pseudo-element-case.md
@@ -9,7 +9,7 @@ Specify lowercase or uppercase for pseudo-element selectors.
  * This pseudo-element selector */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-pseudo-element-colon-notation.md
+++ b/src/main/resources/docs/description/selector-pseudo-element-colon-notation.md
@@ -13,7 +13,7 @@ The `::` notation was chosen for _pseudo-elements_ to establish a discrimination
 
 However, for compatibility with existing style sheets, user agents also accept the previous one-colon notation for _pseudo-elements_ introduced in CSS levels 1 and 2 (namely, `:first-line`, `:first-letter`, `:before` and `:after`).
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/selector-pseudo-element-whitelist.md
+++ b/src/main/resources/docs/description/selector-pseudo-element-whitelist.md
@@ -1,6 +1,6 @@
 # selector-pseudo-element-whitelist
 
-**_Deprecated: Instead use the [`selector-pseudo-element-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/selector-pseudo-element-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`selector-pseudo-element-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/selector-pseudo-element-allowed-list/README.md) rule._**
 
 Specify a list of allowed pseudo-element selectors.
 

--- a/src/main/resources/docs/description/selector-type-case.md
+++ b/src/main/resources/docs/description/selector-type-case.md
@@ -9,7 +9,7 @@ Specify lowercase or uppercase for type selectors.
  * This is type selector */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/shorthand-property-no-redundant-values.md
+++ b/src/main/resources/docs/description/shorthand-property-no-redundant-values.md
@@ -19,7 +19,7 @@ This rule alerts you when you use redundant values in the following shorthand pr
 - `border-width`
 - `grid-gap`
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/string-quotes.md
+++ b/src/main/resources/docs/description/string-quotes.md
@@ -25,7 +25,7 @@ Single quotes in a charset @-rule are ignored as using single quotes in this con
 /* fine regardless of configuration */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/unit-blacklist.md
+++ b/src/main/resources/docs/description/unit-blacklist.md
@@ -1,6 +1,6 @@
 # unit-blacklist
 
-**_Deprecated: Instead use the [`unit-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/unit-disallowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`unit-disallowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/unit-disallowed-list/README.md) rule._**
 
 Specify a list of disallowed units.
 

--- a/src/main/resources/docs/description/unit-case.md
+++ b/src/main/resources/docs/description/unit-case.md
@@ -9,7 +9,7 @@ Specify lowercase or uppercase for units.
  *     These units */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/unit-whitelist.md
+++ b/src/main/resources/docs/description/unit-whitelist.md
@@ -1,6 +1,6 @@
 # unit-whitelist
 
-**_Deprecated: Instead use the [`unit-allowed-list`](https://github.com/stylelint/stylelint/tree/13.7.1/lib/rules/unit-allowed-list/README.md) rule._**
+**_Deprecated: Instead use the [`unit-allowed-list`](https://github.com/stylelint/stylelint/tree/13.13.1/lib/rules/unit-allowed-list/README.md) rule._**
 
 Specify a list of allowed units.
 

--- a/src/main/resources/docs/description/value-keyword-case.md
+++ b/src/main/resources/docs/description/value-keyword-case.md
@@ -11,7 +11,7 @@ Specify lowercase or uppercase for keywords values.
 
 This rule ignores [`<custom-idents>`](https://developer.mozilla.org/en/docs/Web/CSS/custom-ident) of known properties. Keyword values which are paired with non-properties (e.g. `$vars` and custom properties), and do not conform to the primary option, can be ignored using the `ignoreKeywords: []` secondary option.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/value-list-comma-newline-after.md
+++ b/src/main/resources/docs/description/value-list-comma-newline-after.md
@@ -10,7 +10,7 @@ a { background-size: 0,
  * The newline after this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/value-list-comma-space-after.md
+++ b/src/main/resources/docs/description/value-list-comma-space-after.md
@@ -9,7 +9,7 @@ a { background-size: 0, 0; }
  * The space after this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/value-list-comma-space-before.md
+++ b/src/main/resources/docs/description/value-list-comma-space-before.md
@@ -9,7 +9,7 @@ a { background-size: 0 ,0; }
  * The space before this comma */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/value-list-max-empty-lines.md
+++ b/src/main/resources/docs/description/value-list-max-empty-lines.md
@@ -14,7 +14,7 @@ a {
  *       This empty line */
 ```
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/description/value-no-vendor-prefix.md
+++ b/src/main/resources/docs/description/value-no-vendor-prefix.md
@@ -11,7 +11,7 @@ a { display: -webkit-flex; }
 
 This rule will only complain for prefixed _standard_ values, and not for prefixed _proprietary_ or _unknown_ ones.
 
-The [`fix` option](https://github.com/stylelint/stylelint/tree/13.7.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://github.com/stylelint/stylelint/tree/13.13.1/docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/main/resources/docs/multiple-tests/all-patterns-config/results.xml
+++ b/src/main/resources/docs/multiple-tests/all-patterns-config/results.xml
@@ -3,6 +3,6 @@
     <file name="noTestResults.css">
         <error source="scale-unlimited/declaration-strict-value" line="2" message="Expected variable or function for &quot;#aaaaaa&quot; of &quot;color&quot; (scale-unlimited/declaration-strict-value)" severity="info" />
         <error source="sh-waqar/declaration-use-variable" line="2" message="Expected variable for &quot;color&quot;. (sh-waqar/declaration-use-variable)" severity="info" />
-        <error source="color-hex-length" line="2" message="Expected &quot;#aaaaaa&quot; to be &quot;#aaa&quot; (color-hex-length)" severity="error" />
+        <error source="color-hex-length" line="2" message="Expected &quot;#aaaaaa&quot; to be &quot;#aaa&quot; (color-hex-length)" severity="info" />
     </file>
 </checkstyle>

--- a/src/main/resources/docs/multiple-tests/pass-default-parameter/results.xml
+++ b/src/main/resources/docs/multiple-tests/pass-default-parameter/results.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <checkstyle version="1.5">
   <file name="test.css">
-    <error source="block-no-empty" line="1" message="Unexpected empty block (block-no-empty)" severity="error" />
+    <error source="block-no-empty" line="1" message="Unexpected empty block (block-no-empty)" severity="warning" />
   </file>
 </checkstyle>

--- a/src/main/resources/docs/multiple-tests/with-config-file/results.xml
+++ b/src/main/resources/docs/multiple-tests/with-config-file/results.xml
@@ -1,78 +1,78 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <checkstyle version="1.5">
     <file name="test1.css">
-        <error source="color-hex-case" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaaaaa&quot; (color-hex-case)" severity="error" />
-        <error source="color-hex-length" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaa&quot; (color-hex-length)" severity="error" />
+        <error source="color-hex-case" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaaaaa&quot; (color-hex-case)" severity="info" />
+        <error source="color-hex-length" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaa&quot; (color-hex-length)" severity="info" />
 
-        <error source="number-leading-zero" line="15" message="Unexpected leading zero (number-leading-zero)" severity="error" />
+        <error source="number-leading-zero" line="15" message="Unexpected leading zero (number-leading-zero)" severity="info" />
 
-        <error source="indentation" line="2" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="6" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="7" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="11" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="12" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="13" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="14" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="15" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="16" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="20" message="Expected indentation of 2 spaces (indentation)" severity="error" />
+        <error source="indentation" line="2" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="6" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="7" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="11" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="12" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="13" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="14" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="15" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="16" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="20" message="Expected indentation of 2 spaces (indentation)" severity="info" />
 
-        <error source="length-zero-no-unit" line="15" message="Unexpected unit (length-zero-no-unit)" severity="error" />
-        <error source="length-zero-no-unit" line="15" message="Unexpected unit (length-zero-no-unit)" severity="error" />
+        <error source="length-zero-no-unit" line="15" message="Unexpected unit (length-zero-no-unit)" severity="info" />
+        <error source="length-zero-no-unit" line="15" message="Unexpected unit (length-zero-no-unit)" severity="info" />
     </file>
     <file name="test2.less">
-        <error source="color-hex-case" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaaaaa&quot; (color-hex-case)" severity="error" />
-        <error source="color-hex-length" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaa&quot; (color-hex-length)" severity="error" />
+        <error source="color-hex-case" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaaaaa&quot; (color-hex-case)" severity="info" />
+        <error source="color-hex-length" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaa&quot; (color-hex-length)" severity="info" />
 
-        <error source="number-leading-zero" line="14" message="Unexpected leading zero (number-leading-zero)" severity="error" />
+        <error source="number-leading-zero" line="14" message="Unexpected leading zero (number-leading-zero)" severity="info" />
 
-        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="error" />
-        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="error" />
+        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="info" />
+        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="info" />
 
-        <error source="no-eol-whitespace" line="4" message="Unexpected whitespace at end of line (no-eol-whitespace)" severity="error" />
-        <error source="no-eol-whitespace" line="8" message="Unexpected whitespace at end of line (no-eol-whitespace)" severity="error" />
-        <error source="no-eol-whitespace" line="17" message="Unexpected whitespace at end of line (no-eol-whitespace)" severity="error" />
+        <error source="no-eol-whitespace" line="4" message="Unexpected whitespace at end of line (no-eol-whitespace)" severity="info" />
+        <error source="no-eol-whitespace" line="8" message="Unexpected whitespace at end of line (no-eol-whitespace)" severity="info" />
+        <error source="no-eol-whitespace" line="17" message="Unexpected whitespace at end of line (no-eol-whitespace)" severity="info" />
 
-        <error source="indentation" line="2" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="3" message="Expected indentation of 0 spaces (indentation)" severity="error" />
-        <error source="indentation" line="5" message="Expected indentation of 0 spaces (indentation)" severity="error" />
-        <error source="indentation" line="6" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="7" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="9" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="10" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="11" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="12" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="13" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="14" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="15" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="16" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="18" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="19" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="20" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="21" message="Expected indentation of 0 spaces (indentation)" severity="error" />
+        <error source="indentation" line="2" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="3" message="Expected indentation of 0 spaces (indentation)" severity="info" />
+        <error source="indentation" line="5" message="Expected indentation of 0 spaces (indentation)" severity="info" />
+        <error source="indentation" line="6" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="7" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="9" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="10" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="11" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="12" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="13" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="14" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="15" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="16" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="18" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="19" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="20" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="21" message="Expected indentation of 0 spaces (indentation)" severity="info" />
     </file>
     <file name="test3.scss">
-        <error source="color-hex-case" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaaaaa&quot; (color-hex-case)" severity="error" />
-        <error source="color-hex-length" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaa&quot; (color-hex-length)" severity="error" />
+        <error source="color-hex-case" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaaaaa&quot; (color-hex-case)" severity="info" />
+        <error source="color-hex-length" line="2" message="Expected &quot;#aaaAaa&quot; to be &quot;#aaa&quot; (color-hex-length)" severity="info" />
 
-        <error source="number-leading-zero" line="14" message="Unexpected leading zero (number-leading-zero)" severity="error" />
+        <error source="number-leading-zero" line="14" message="Unexpected leading zero (number-leading-zero)" severity="info" />
 
-        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="error" />
-        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="error" />
+        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="info" />
+        <error source="length-zero-no-unit" line="14" message="Unexpected unit (length-zero-no-unit)" severity="info" />
 
-        <error source="indentation" line="2" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="6" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="7" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="9" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="10" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="11" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="12" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="13" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="14" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="15" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="16" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="18" message="Expected indentation of 2 spaces (indentation)" severity="error" />
-        <error source="indentation" line="19" message="Expected indentation of 4 spaces (indentation)" severity="error" />
-        <error source="indentation" line="20" message="Expected indentation of 2 spaces (indentation)" severity="error" />
+        <error source="indentation" line="2" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="6" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="7" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="9" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="10" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="11" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="12" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="13" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="14" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="15" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="16" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="18" message="Expected indentation of 2 spaces (indentation)" severity="info" />
+        <error source="indentation" line="19" message="Expected indentation of 4 spaces (indentation)" severity="info" />
+        <error source="indentation" line="20" message="Expected indentation of 2 spaces (indentation)" severity="info" />
     </file>
 </checkstyle>

--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -1,9 +1,9 @@
 {
   "name" : "stylelint",
-  "version" : "13.7.1",
+  "version" : "13.13.1",
   "patterns" : [ {
     "patternId" : "alpha-value-notation",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "alpha-value-notation",
@@ -13,7 +13,7 @@
     "enabled" : false
   }, {
     "patternId" : "at-rule-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-allowed-list",
@@ -23,7 +23,7 @@
     "enabled" : false
   }, {
     "patternId" : "at-rule-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-blacklist",
@@ -33,7 +33,7 @@
     "enabled" : false
   }, {
     "patternId" : "at-rule-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-disallowed-list",
@@ -43,7 +43,7 @@
     "enabled" : false
   }, {
     "patternId" : "at-rule-empty-line-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-empty-line-before",
@@ -56,7 +56,7 @@
     "enabled" : true
   }, {
     "patternId" : "at-rule-name-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-name-case",
@@ -66,7 +66,7 @@
     "enabled" : true
   }, {
     "patternId" : "at-rule-name-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-name-newline-after",
@@ -76,7 +76,7 @@
     "enabled" : false
   }, {
     "patternId" : "at-rule-name-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-name-space-after",
@@ -86,7 +86,7 @@
     "enabled" : true
   }, {
     "patternId" : "at-rule-no-unknown",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-no-unknown",
@@ -96,7 +96,7 @@
     "enabled" : true
   }, {
     "patternId" : "at-rule-no-vendor-prefix",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-no-vendor-prefix",
@@ -106,7 +106,7 @@
     "enabled" : false
   }, {
     "patternId" : "at-rule-property-required-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-property-required-list",
@@ -116,7 +116,7 @@
     "enabled" : false
   }, {
     "patternId" : "at-rule-property-requirelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-property-requirelist",
@@ -126,7 +126,7 @@
     "enabled" : false
   }, {
     "patternId" : "at-rule-semicolon-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-semicolon-newline-after",
@@ -136,7 +136,7 @@
     "enabled" : true
   }, {
     "patternId" : "at-rule-semicolon-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-semicolon-space-before",
@@ -146,7 +146,7 @@
     "enabled" : false
   }, {
     "patternId" : "at-rule-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "at-rule-whitelist",
@@ -156,7 +156,7 @@
     "enabled" : false
   }, {
     "patternId" : "block-closing-brace-empty-line-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-closing-brace-empty-line-before",
@@ -166,7 +166,7 @@
     "enabled" : true
   }, {
     "patternId" : "block-closing-brace-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-closing-brace-newline-after",
@@ -176,7 +176,7 @@
     "enabled" : true
   }, {
     "patternId" : "block-closing-brace-newline-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-closing-brace-newline-before",
@@ -186,7 +186,7 @@
     "enabled" : true
   }, {
     "patternId" : "block-closing-brace-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-closing-brace-space-after",
@@ -196,7 +196,7 @@
     "enabled" : false
   }, {
     "patternId" : "block-closing-brace-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-closing-brace-space-before",
@@ -206,7 +206,7 @@
     "enabled" : true
   }, {
     "patternId" : "block-no-empty",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-no-empty",
@@ -216,7 +216,7 @@
     "enabled" : true
   }, {
     "patternId" : "block-opening-brace-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-opening-brace-newline-after",
@@ -226,7 +226,7 @@
     "enabled" : true
   }, {
     "patternId" : "block-opening-brace-newline-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-opening-brace-newline-before",
@@ -236,7 +236,7 @@
     "enabled" : false
   }, {
     "patternId" : "block-opening-brace-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-opening-brace-space-after",
@@ -246,7 +246,7 @@
     "enabled" : true
   }, {
     "patternId" : "block-opening-brace-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "block-opening-brace-space-before",
@@ -256,7 +256,7 @@
     "enabled" : true
   }, {
     "patternId" : "color-function-notation",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "color-function-notation",
@@ -266,7 +266,7 @@
     "enabled" : false
   }, {
     "patternId" : "color-hex-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "color-hex-case",
@@ -276,7 +276,7 @@
     "enabled" : true
   }, {
     "patternId" : "color-hex-length",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "color-hex-length",
@@ -286,7 +286,7 @@
     "enabled" : true
   }, {
     "patternId" : "color-named",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "color-named",
@@ -296,7 +296,7 @@
     "enabled" : false
   }, {
     "patternId" : "color-no-hex",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "color-no-hex",
@@ -306,7 +306,7 @@
     "enabled" : false
   }, {
     "patternId" : "color-no-invalid-hex",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "color-no-invalid-hex",
@@ -316,7 +316,7 @@
     "enabled" : true
   }, {
     "patternId" : "comment-empty-line-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "comment-empty-line-before",
@@ -329,7 +329,7 @@
     "enabled" : true
   }, {
     "patternId" : "comment-no-empty",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "comment-no-empty",
@@ -338,8 +338,18 @@
     "languages" : [ ],
     "enabled" : true
   }, {
+    "patternId" : "comment-pattern",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "parameters" : [ {
+      "name" : "comment-pattern",
+      "default" : null
+    } ],
+    "languages" : [ ],
+    "enabled" : false
+  }, {
     "patternId" : "comment-whitespace-inside",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "comment-whitespace-inside",
@@ -349,7 +359,7 @@
     "enabled" : true
   }, {
     "patternId" : "comment-word-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "comment-word-blacklist",
@@ -359,7 +369,7 @@
     "enabled" : false
   }, {
     "patternId" : "comment-word-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "comment-word-disallowed-list",
@@ -369,7 +379,7 @@
     "enabled" : false
   }, {
     "patternId" : "custom-media-pattern",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "custom-media-pattern",
@@ -379,7 +389,7 @@
     "enabled" : false
   }, {
     "patternId" : "custom-property-empty-line-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "custom-property-empty-line-before",
@@ -392,7 +402,7 @@
     "enabled" : true
   }, {
     "patternId" : "custom-property-pattern",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "custom-property-pattern",
@@ -402,7 +412,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-bang-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-bang-space-after",
@@ -412,7 +422,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-bang-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-bang-space-before",
@@ -421,8 +431,18 @@
     "languages" : [ ],
     "enabled" : true
   }, {
+    "patternId" : "declaration-block-no-duplicate-custom-properties",
+    "level" : "Warning",
+    "category" : "CodeStyle",
+    "parameters" : [ {
+      "name" : "declaration-block-no-duplicate-custom-properties",
+      "default" : null
+    } ],
+    "languages" : [ ],
+    "enabled" : false
+  }, {
     "patternId" : "declaration-block-no-duplicate-properties",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-block-no-duplicate-properties",
@@ -434,7 +454,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-block-no-redundant-longhand-properties",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-block-no-redundant-longhand-properties",
@@ -444,7 +464,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-block-no-shorthand-property-overrides",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-block-no-shorthand-property-overrides",
@@ -454,7 +474,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-block-semicolon-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-block-semicolon-newline-after",
@@ -464,7 +484,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-block-semicolon-newline-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-block-semicolon-newline-before",
@@ -474,7 +494,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-block-semicolon-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-block-semicolon-space-after",
@@ -484,7 +504,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-block-semicolon-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-block-semicolon-space-before",
@@ -494,7 +514,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-block-single-line-max-declarations",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-block-single-line-max-declarations",
@@ -504,7 +524,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-block-trailing-semicolon",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-block-trailing-semicolon",
@@ -514,7 +534,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-colon-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-colon-newline-after",
@@ -524,7 +544,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-colon-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-colon-space-after",
@@ -534,7 +554,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-colon-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-colon-space-before",
@@ -544,7 +564,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-empty-line-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-empty-line-before",
@@ -557,7 +577,7 @@
     "enabled" : true
   }, {
     "patternId" : "declaration-no-important",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-no-important",
@@ -567,7 +587,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-property-unit-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-property-unit-allowed-list",
@@ -577,7 +597,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-property-unit-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-property-unit-blacklist",
@@ -587,7 +607,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-property-unit-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-property-unit-disallowed-list",
@@ -597,7 +617,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-property-unit-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-property-unit-whitelist",
@@ -607,7 +627,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-property-value-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-property-value-allowed-list",
@@ -617,7 +637,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-property-value-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-property-value-blacklist",
@@ -627,7 +647,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-property-value-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-property-value-disallowed-list",
@@ -637,7 +657,7 @@
     "enabled" : false
   }, {
     "patternId" : "declaration-property-value-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "declaration-property-value-whitelist",
@@ -647,7 +667,7 @@
     "enabled" : false
   }, {
     "patternId" : "font-family-name-quotes",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "font-family-name-quotes",
@@ -657,7 +677,7 @@
     "enabled" : false
   }, {
     "patternId" : "font-family-no-duplicate-names",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "font-family-no-duplicate-names",
@@ -667,7 +687,7 @@
     "enabled" : true
   }, {
     "patternId" : "font-family-no-missing-generic-family-keyword",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "font-family-no-missing-generic-family-keyword",
@@ -677,7 +697,7 @@
     "enabled" : true
   }, {
     "patternId" : "font-weight-notation",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "font-weight-notation",
@@ -687,7 +707,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-allowed-list",
@@ -697,7 +717,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-blacklist",
@@ -707,7 +727,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-calc-no-invalid",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-calc-no-invalid",
@@ -717,7 +737,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-calc-no-unspaced-operator",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-calc-no-unspaced-operator",
@@ -727,7 +747,7 @@
     "enabled" : true
   }, {
     "patternId" : "function-comma-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-comma-newline-after",
@@ -737,7 +757,7 @@
     "enabled" : true
   }, {
     "patternId" : "function-comma-newline-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-comma-newline-before",
@@ -747,7 +767,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-comma-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-comma-space-after",
@@ -757,7 +777,7 @@
     "enabled" : true
   }, {
     "patternId" : "function-comma-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-comma-space-before",
@@ -767,7 +787,7 @@
     "enabled" : true
   }, {
     "patternId" : "function-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-disallowed-list",
@@ -777,7 +797,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-linear-gradient-no-nonstandard-direction",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-linear-gradient-no-nonstandard-direction",
@@ -787,7 +807,7 @@
     "enabled" : true
   }, {
     "patternId" : "function-max-empty-lines",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-max-empty-lines",
@@ -797,7 +817,7 @@
     "enabled" : true
   }, {
     "patternId" : "function-name-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-name-case",
@@ -807,7 +827,7 @@
     "enabled" : true
   }, {
     "patternId" : "function-parentheses-newline-inside",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-parentheses-newline-inside",
@@ -817,7 +837,7 @@
     "enabled" : true
   }, {
     "patternId" : "function-parentheses-space-inside",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-parentheses-space-inside",
@@ -827,7 +847,7 @@
     "enabled" : true
   }, {
     "patternId" : "function-url-no-scheme-relative",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-url-no-scheme-relative",
@@ -837,7 +857,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-url-quotes",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-url-quotes",
@@ -847,7 +867,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-url-scheme-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-url-scheme-allowed-list",
@@ -857,7 +877,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-url-scheme-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-url-scheme-blacklist",
@@ -867,7 +887,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-url-scheme-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-url-scheme-disallowed-list",
@@ -877,7 +897,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-url-scheme-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-url-scheme-whitelist",
@@ -887,7 +907,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-whitelist",
@@ -897,7 +917,7 @@
     "enabled" : false
   }, {
     "patternId" : "function-whitespace-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "function-whitespace-after",
@@ -907,7 +927,7 @@
     "enabled" : true
   }, {
     "patternId" : "hue-degree-notation",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "hue-degree-notation",
@@ -917,7 +937,7 @@
     "enabled" : false
   }, {
     "patternId" : "indentation",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "indentation",
@@ -927,7 +947,7 @@
     "enabled" : true
   }, {
     "patternId" : "keyframe-declaration-no-important",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "keyframe-declaration-no-important",
@@ -937,7 +957,7 @@
     "enabled" : true
   }, {
     "patternId" : "keyframes-name-pattern",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "keyframes-name-pattern",
@@ -947,7 +967,7 @@
     "enabled" : false
   }, {
     "patternId" : "length-zero-no-unit",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "length-zero-no-unit",
@@ -957,7 +977,7 @@
     "enabled" : true
   }, {
     "patternId" : "linebreaks",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "linebreaks",
@@ -967,7 +987,7 @@
     "enabled" : false
   }, {
     "patternId" : "max-empty-lines",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "max-empty-lines",
@@ -977,7 +997,7 @@
     "enabled" : true
   }, {
     "patternId" : "max-line-length",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "max-line-length",
@@ -987,7 +1007,7 @@
     "enabled" : false
   }, {
     "patternId" : "max-nesting-depth",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "max-nesting-depth",
@@ -997,7 +1017,7 @@
     "enabled" : false
   }, {
     "patternId" : "media-feature-colon-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-colon-space-after",
@@ -1007,7 +1027,7 @@
     "enabled" : true
   }, {
     "patternId" : "media-feature-colon-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-colon-space-before",
@@ -1017,7 +1037,7 @@
     "enabled" : true
   }, {
     "patternId" : "media-feature-name-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-name-allowed-list",
@@ -1027,7 +1047,7 @@
     "enabled" : false
   }, {
     "patternId" : "media-feature-name-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-name-blacklist",
@@ -1037,7 +1057,7 @@
     "enabled" : false
   }, {
     "patternId" : "media-feature-name-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-name-case",
@@ -1047,7 +1067,7 @@
     "enabled" : true
   }, {
     "patternId" : "media-feature-name-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-name-disallowed-list",
@@ -1057,7 +1077,7 @@
     "enabled" : false
   }, {
     "patternId" : "media-feature-name-no-unknown",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-name-no-unknown",
@@ -1067,7 +1087,7 @@
     "enabled" : true
   }, {
     "patternId" : "media-feature-name-no-vendor-prefix",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-name-no-vendor-prefix",
@@ -1077,7 +1097,7 @@
     "enabled" : false
   }, {
     "patternId" : "media-feature-name-value-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-name-value-allowed-list",
@@ -1087,7 +1107,7 @@
     "enabled" : false
   }, {
     "patternId" : "media-feature-name-value-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-name-value-whitelist",
@@ -1097,7 +1117,7 @@
     "enabled" : false
   }, {
     "patternId" : "media-feature-name-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-name-whitelist",
@@ -1107,7 +1127,7 @@
     "enabled" : false
   }, {
     "patternId" : "media-feature-parentheses-space-inside",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-parentheses-space-inside",
@@ -1117,7 +1137,7 @@
     "enabled" : true
   }, {
     "patternId" : "media-feature-range-operator-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-range-operator-space-after",
@@ -1127,7 +1147,7 @@
     "enabled" : true
   }, {
     "patternId" : "media-feature-range-operator-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-feature-range-operator-space-before",
@@ -1137,7 +1157,7 @@
     "enabled" : true
   }, {
     "patternId" : "media-query-list-comma-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-query-list-comma-newline-after",
@@ -1147,7 +1167,7 @@
     "enabled" : true
   }, {
     "patternId" : "media-query-list-comma-newline-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-query-list-comma-newline-before",
@@ -1157,7 +1177,7 @@
     "enabled" : false
   }, {
     "patternId" : "media-query-list-comma-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-query-list-comma-space-after",
@@ -1167,7 +1187,7 @@
     "enabled" : true
   }, {
     "patternId" : "media-query-list-comma-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "media-query-list-comma-space-before",
@@ -1176,8 +1196,18 @@
     "languages" : [ ],
     "enabled" : true
   }, {
+    "patternId" : "named-grid-areas-no-invalid",
+    "level" : "Warning",
+    "category" : "CodeStyle",
+    "parameters" : [ {
+      "name" : "named-grid-areas-no-invalid",
+      "default" : null
+    } ],
+    "languages" : [ ],
+    "enabled" : false
+  }, {
     "patternId" : "no-descending-specificity",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-descending-specificity",
@@ -1187,7 +1217,7 @@
     "enabled" : true
   }, {
     "patternId" : "no-duplicate-at-import-rules",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-duplicate-at-import-rules",
@@ -1197,7 +1227,7 @@
     "enabled" : true
   }, {
     "patternId" : "no-duplicate-selectors",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-duplicate-selectors",
@@ -1207,7 +1237,7 @@
     "enabled" : true
   }, {
     "patternId" : "no-empty-first-line",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-empty-first-line",
@@ -1217,7 +1247,7 @@
     "enabled" : false
   }, {
     "patternId" : "no-empty-source",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-empty-source",
@@ -1227,7 +1257,7 @@
     "enabled" : true
   }, {
     "patternId" : "no-eol-whitespace",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-eol-whitespace",
@@ -1237,7 +1267,7 @@
     "enabled" : true
   }, {
     "patternId" : "no-extra-semicolons",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-extra-semicolons",
@@ -1247,7 +1277,7 @@
     "enabled" : true
   }, {
     "patternId" : "no-invalid-double-slash-comments",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-invalid-double-slash-comments",
@@ -1256,8 +1286,28 @@
     "languages" : [ ],
     "enabled" : true
   }, {
+    "patternId" : "no-invalid-position-at-import-rule",
+    "level" : "Warning",
+    "category" : "CodeStyle",
+    "parameters" : [ {
+      "name" : "no-invalid-position-at-import-rule",
+      "default" : null
+    } ],
+    "languages" : [ ],
+    "enabled" : false
+  }, {
+    "patternId" : "no-irregular-whitespace",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "parameters" : [ {
+      "name" : "no-irregular-whitespace",
+      "default" : null
+    } ],
+    "languages" : [ ],
+    "enabled" : false
+  }, {
     "patternId" : "no-missing-end-of-source-newline",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-missing-end-of-source-newline",
@@ -1267,7 +1317,7 @@
     "enabled" : true
   }, {
     "patternId" : "no-unknown-animations",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "no-unknown-animations",
@@ -1277,7 +1327,7 @@
     "enabled" : false
   }, {
     "patternId" : "number-leading-zero",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "number-leading-zero",
@@ -1287,7 +1337,7 @@
     "enabled" : true
   }, {
     "patternId" : "number-max-precision",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "number-max-precision",
@@ -1297,7 +1347,7 @@
     "enabled" : false
   }, {
     "patternId" : "number-no-trailing-zeros",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "number-no-trailing-zeros",
@@ -1307,7 +1357,7 @@
     "enabled" : true
   }, {
     "patternId" : "property-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "property-allowed-list",
@@ -1317,7 +1367,7 @@
     "enabled" : false
   }, {
     "patternId" : "property-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "property-blacklist",
@@ -1327,7 +1377,7 @@
     "enabled" : false
   }, {
     "patternId" : "property-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "property-case",
@@ -1337,7 +1387,7 @@
     "enabled" : true
   }, {
     "patternId" : "property-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "property-disallowed-list",
@@ -1347,7 +1397,7 @@
     "enabled" : false
   }, {
     "patternId" : "property-no-unknown",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "property-no-unknown",
@@ -1357,7 +1407,7 @@
     "enabled" : true
   }, {
     "patternId" : "property-no-vendor-prefix",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "property-no-vendor-prefix",
@@ -1367,7 +1417,7 @@
     "enabled" : false
   }, {
     "patternId" : "property-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "property-whitelist",
@@ -1377,7 +1427,7 @@
     "enabled" : false
   }, {
     "patternId" : "rule-empty-line-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "rule-empty-line-before",
@@ -1390,7 +1440,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-attribute-brackets-space-inside",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-attribute-brackets-space-inside",
@@ -1399,8 +1449,18 @@
     "languages" : [ ],
     "enabled" : true
   }, {
+    "patternId" : "selector-attribute-name-disallowed-list",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "parameters" : [ {
+      "name" : "selector-attribute-name-disallowed-list",
+      "default" : null
+    } ],
+    "languages" : [ ],
+    "enabled" : false
+  }, {
     "patternId" : "selector-attribute-operator-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-attribute-operator-allowed-list",
@@ -1410,7 +1470,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-attribute-operator-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-attribute-operator-blacklist",
@@ -1420,7 +1480,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-attribute-operator-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-attribute-operator-disallowed-list",
@@ -1430,7 +1490,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-attribute-operator-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-attribute-operator-space-after",
@@ -1440,7 +1500,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-attribute-operator-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-attribute-operator-space-before",
@@ -1450,7 +1510,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-attribute-operator-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-attribute-operator-whitelist",
@@ -1460,7 +1520,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-attribute-quotes",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-attribute-quotes",
@@ -1470,7 +1530,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-class-pattern",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-class-pattern",
@@ -1480,7 +1540,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-combinator-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-combinator-allowed-list",
@@ -1490,7 +1550,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-combinator-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-combinator-blacklist",
@@ -1500,7 +1560,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-combinator-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-combinator-disallowed-list",
@@ -1510,7 +1570,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-combinator-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-combinator-space-after",
@@ -1520,7 +1580,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-combinator-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-combinator-space-before",
@@ -1530,7 +1590,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-combinator-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-combinator-whitelist",
@@ -1540,7 +1600,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-descendant-combinator-no-non-space",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-descendant-combinator-no-non-space",
@@ -1549,8 +1609,18 @@
     "languages" : [ ],
     "enabled" : true
   }, {
+    "patternId" : "selector-disallowed-list",
+    "level" : "Info",
+    "category" : "CodeStyle",
+    "parameters" : [ {
+      "name" : "selector-disallowed-list",
+      "default" : null
+    } ],
+    "languages" : [ ],
+    "enabled" : false
+  }, {
     "patternId" : "selector-id-pattern",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-id-pattern",
@@ -1560,7 +1630,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-list-comma-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-list-comma-newline-after",
@@ -1570,7 +1640,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-list-comma-newline-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-list-comma-newline-before",
@@ -1580,7 +1650,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-list-comma-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-list-comma-space-after",
@@ -1590,7 +1660,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-list-comma-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-list-comma-space-before",
@@ -1600,7 +1670,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-max-attribute",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-attribute",
@@ -1610,7 +1680,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-max-class",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-class",
@@ -1620,7 +1690,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-max-combinators",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-combinators",
@@ -1630,7 +1700,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-max-compound-selectors",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-compound-selectors",
@@ -1640,7 +1710,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-max-empty-lines",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-empty-lines",
@@ -1650,7 +1720,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-max-id",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-id",
@@ -1660,7 +1730,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-max-pseudo-class",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-pseudo-class",
@@ -1670,7 +1740,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-max-specificity",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-specificity",
@@ -1680,7 +1750,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-max-type",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-type",
@@ -1690,7 +1760,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-max-universal",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-max-universal",
@@ -1700,7 +1770,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-nested-pattern",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-nested-pattern",
@@ -1710,7 +1780,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-no-qualifying-type",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-no-qualifying-type",
@@ -1720,7 +1790,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-no-vendor-prefix",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-no-vendor-prefix",
@@ -1730,7 +1800,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-pseudo-class-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-class-allowed-list",
@@ -1740,7 +1810,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-pseudo-class-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-class-blacklist",
@@ -1750,7 +1820,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-pseudo-class-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-class-case",
@@ -1760,7 +1830,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-pseudo-class-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-class-disallowed-list",
@@ -1770,7 +1840,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-pseudo-class-no-unknown",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-class-no-unknown",
@@ -1780,7 +1850,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-pseudo-class-parentheses-space-inside",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-class-parentheses-space-inside",
@@ -1790,7 +1860,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-pseudo-class-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-class-whitelist",
@@ -1800,7 +1870,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-pseudo-element-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-element-allowed-list",
@@ -1810,7 +1880,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-pseudo-element-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-element-blacklist",
@@ -1820,7 +1890,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-pseudo-element-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-element-case",
@@ -1830,7 +1900,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-pseudo-element-colon-notation",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-element-colon-notation",
@@ -1840,7 +1910,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-pseudo-element-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-element-disallowed-list",
@@ -1850,7 +1920,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-pseudo-element-no-unknown",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-element-no-unknown",
@@ -1860,7 +1930,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-pseudo-element-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-pseudo-element-whitelist",
@@ -1870,7 +1940,7 @@
     "enabled" : false
   }, {
     "patternId" : "selector-type-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-type-case",
@@ -1880,7 +1950,7 @@
     "enabled" : true
   }, {
     "patternId" : "selector-type-no-unknown",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "selector-type-no-unknown",
@@ -1890,7 +1960,7 @@
     "enabled" : true
   }, {
     "patternId" : "shorthand-property-no-redundant-values",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "shorthand-property-no-redundant-values",
@@ -1900,7 +1970,7 @@
     "enabled" : false
   }, {
     "patternId" : "string-no-newline",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "string-no-newline",
@@ -1910,7 +1980,7 @@
     "enabled" : true
   }, {
     "patternId" : "string-quotes",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "string-quotes",
@@ -1920,7 +1990,7 @@
     "enabled" : false
   }, {
     "patternId" : "time-min-milliseconds",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "time-min-milliseconds",
@@ -1930,7 +2000,7 @@
     "enabled" : false
   }, {
     "patternId" : "unicode-bom",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "unicode-bom",
@@ -1940,7 +2010,7 @@
     "enabled" : false
   }, {
     "patternId" : "unit-allowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "unit-allowed-list",
@@ -1950,7 +2020,7 @@
     "enabled" : false
   }, {
     "patternId" : "unit-blacklist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "unit-blacklist",
@@ -1960,7 +2030,7 @@
     "enabled" : false
   }, {
     "patternId" : "unit-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "unit-case",
@@ -1970,7 +2040,7 @@
     "enabled" : true
   }, {
     "patternId" : "unit-disallowed-list",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "unit-disallowed-list",
@@ -1980,7 +2050,7 @@
     "enabled" : false
   }, {
     "patternId" : "unit-no-unknown",
-    "level" : "Error",
+    "level" : "Warning",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "unit-no-unknown",
@@ -1990,7 +2060,7 @@
     "enabled" : true
   }, {
     "patternId" : "unit-whitelist",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "unit-whitelist",
@@ -2000,7 +2070,7 @@
     "enabled" : false
   }, {
     "patternId" : "value-keyword-case",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "value-keyword-case",
@@ -2010,7 +2080,7 @@
     "enabled" : false
   }, {
     "patternId" : "value-list-comma-newline-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "value-list-comma-newline-after",
@@ -2020,7 +2090,7 @@
     "enabled" : true
   }, {
     "patternId" : "value-list-comma-newline-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "value-list-comma-newline-before",
@@ -2030,7 +2100,7 @@
     "enabled" : false
   }, {
     "patternId" : "value-list-comma-space-after",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "value-list-comma-space-after",
@@ -2040,7 +2110,7 @@
     "enabled" : true
   }, {
     "patternId" : "value-list-comma-space-before",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "value-list-comma-space-before",
@@ -2050,7 +2120,7 @@
     "enabled" : true
   }, {
     "patternId" : "value-list-max-empty-lines",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "value-list-max-empty-lines",
@@ -2060,7 +2130,7 @@
     "enabled" : true
   }, {
     "patternId" : "value-no-vendor-prefix",
-    "level" : "Error",
+    "level" : "Info",
     "category" : "CodeStyle",
     "parameters" : [ {
       "name" : "value-no-vendor-prefix",

--- a/src/main/resources/docs/tests/block-closing-brace-newline-after.css
+++ b/src/main/resources/docs/tests/block-closing-brace-newline-after.css
@@ -2,7 +2,7 @@
 
 a {
     color: pink;
-    /*#Err: block-closing-brace-newline-after*/
+    /*#Info: block-closing-brace-newline-after*/
 }  b {
     color: red;
 }

--- a/src/main/resources/docs/tests/indentation.less
+++ b/src/main/resources/docs/tests/indentation.less
@@ -1,5 +1,5 @@
 /*#Patterns: indentation : {"indentation":"100"}*/
-/*#Issue: {"severity": "Err", "line": 5, "patternId": "indentation"}*/
+/*#Issue: {"severity": "Info", "line": 5, "patternId": "indentation"}*/
 
 p {
   color: blue;

--- a/src/main/resources/docs/tests/selector-list-comma-newline-after.scss
+++ b/src/main/resources/docs/tests/selector-list-comma-newline-after.scss
@@ -1,6 +1,6 @@
 /*#Patterns: selector-list-comma-newline-after : {"selector-list-comma-newline-after" : "always"}*/
 
-/*#Err: selector-list-comma-newline-after*/
+/*#Info: selector-list-comma-newline-after*/
 a, b {
   color: pink;
 }

--- a/src/main/scala/codacy/stylelint/CodacyValues.scala
+++ b/src/main/scala/codacy/stylelint/CodacyValues.scala
@@ -1,8 +1,8 @@
 package codacy.stylelint
 
-object DefaultPatterns {
+object CodacyValues {
 
-  val patterns = Set(
+  val patternsEnabled = Set(
     "at-rule-empty-line-before",
     "at-rule-name-case",
     "at-rule-name-space-after",
@@ -99,4 +99,35 @@ object DefaultPatterns {
     "value-list-comma-space-after",
     "value-list-comma-space-before",
     "value-list-max-empty-lines")
+
+  //Gathered the rules within the category of "Possible errors" of the tool https://stylelint.io/user-guide/rules/list/#possible-errors
+  val possibleErrorsPatterns = Set(
+    "at-rule-no-unknown",
+    "block-no-empty",
+    "color-no-invalid-hex",
+    "comment-no-empty",
+    "declaration-block-no-duplicate-custom-properties",
+    "declaration-block-no-duplicate-properties",
+    "declaration-block-no-shorthand-property-overrides",
+    "font-family-no-duplicate-names",
+    "font-family-no-missing-generic-family-keyword",
+    "function-calc-no-invalid",
+    "function-calc-no-unspaced-operator",
+    "function-linear-gradient-no-nonstandard-direction",
+    "keyframe-declaration-no-important",
+    "media-feature-name-no-unknown",
+    "named-grid-areas-no-invalid",
+    "no-descending-specificity",
+    "no-duplicate-at-import-rules",
+    "no-duplicate-selectors",
+    "no-empty-source",
+    "no-extra-semicolons",
+    "no-invalid-double-slash-comments",
+    "no-invalid-position-at-import-rule",
+    "property-no-unknown",
+    "selector-pseudo-class-no-unknown",
+    "selector-pseudo-element-no-unknown",
+    "selector-type-no-unknown",
+    "string-no-newline",
+    "unit-no-unknown")
 }

--- a/src/main/scala/codacy/stylelint/DocGenerator.scala
+++ b/src/main/scala/codacy/stylelint/DocGenerator.scala
@@ -48,14 +48,9 @@ object DocGenerator {
 
   def addNewPattern(patternName: String, default: Parameter.Value): Pattern.Specification = {
     val param = Set(Parameter.Specification(Parameter.Name(patternName), default))
-    val enabled = DefaultPatterns.patterns.contains(patternName)
-    Pattern.Specification(
-      Pattern.Id(patternName),
-      Result.Level.Err,
-      Pattern.Category.CodeStyle,
-      None,
-      param,
-      enabled = enabled)
+    val enabled = CodacyValues.patternsEnabled.contains(patternName)
+    val level = if (CodacyValues.possibleErrorsPatterns.contains(patternName)) Result.Level.Warn else Result.Level.Info
+    Pattern.Specification(Pattern.Id(patternName), level, Pattern.Category.CodeStyle, None, param, enabled = enabled)
   }
 
   def PatternsFromDefaultConfig(): Map[String, Parameter.Value] = {


### PR DESCRIPTION
I separated my changes in three commits:
- My suggestion to improve the level
  - I couldn't figure out if there was an automatic way to find out this group of rules / category they display [in their website](https://stylelint.io/user-guide/rules/list). Anyway, as a tool for css I left the codacy category as codestyle and created two severities: warn (https://stylelint.io/user-guide/rules/list/#possible-errors) & info (all the others)

- Doc generator result (Did I do this right?? 👀  A lot of files)
- Fixing tests